### PR TITLE
Implement jump and dynamic chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project provides a small 3D sandbox demo built with [Three.js](https://thre
 - Switch between first and third person using the `A` key.
 - Movement with `Z`, `Q`, `S`, `D` and jump with space.
 - Press `Escape` to open the menu where you can adjust render distance and resume with the **Sauvegarder** button.
+- Chunks are loaded and unloaded around the player based on the selected render distance.
 
 ## Running
 Open `index.html` in a modern web browser that supports WebGL. Click on the page to lock the pointer and start moving.


### PR DESCRIPTION
## Summary
- allow player jumping and detect ground collisions
- track nearby chunks and load/unload them based on render distance
- hook the menu's range slider to update render distance
- document chunk loading behaviour in README

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_b_685a8dd9c7c88326a1835317ef2bc1d7