### PR TITLE
Implement jump and dynamic chunk loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This project provides a small 3D sandbox demo built with [Three.js](https://thre
 ## Features
 - Simple terrain made of grey blocks with a flat bottom layer.
 - Random mountains and valleys generated with Perlin noise.
-- Green rectangular player with gravity and collision.
+- Green rectangular player with gravity, jump and collision.
 - Switch between first and third person using the `A` key.
 - Movement with `Z`, `Q`, `S`, `D` and jump with space.
+- Dynamic chunks keep the world around the player up to a configurable render distance.
 - Press `Escape` to open the menu where you can adjust render distance and resume with the **Sauvegarder** button.
 
 ## Running


### PR DESCRIPTION
## Summary
- enable jump with Space key and use key codes
- maintain player ability to jump based on collision state
- keep only surrounding chunks loaded and allow changing render distance from menu
- update menu behavior and docs

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_685a8dd9c7c88326a1835317ef2bc1d7