### PR TITLE
Add jumping and chunk management

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This project provides a small 3D sandbox demo built with [Three.js](https://thre
 - Random mountains and valleys generated with Perlin noise.
 - Green rectangular player with gravity and collision.
 - Switch between first and third person using the `A` key.
-- Movement with `Z`, `Q`, `S`, `D` and jump with space.
+- Movement with `Z`, `Q`, `S`, `D` and jump with the space bar.
 - Press `Escape` to open the menu where you can adjust render distance and resume with the **Sauvegarder** button.
+- Chunks are generated around the player based on the chosen render distance.
 
 ## Running
 Open `index.html` in a modern web browser that supports WebGL. Click on the page to lock the pointer and start moving.


### PR DESCRIPTION
## Summary
- improve README instructions
- add tracking of ground state and implement jumping with space bar
- generate and clear chunks based on render distance
- support adjusting render distance from menu
- dynamically load chunks around the player

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_b_685a8dd9c7c88326a1835317ef2bc1d7