### PR TITLE
Restore demo with save support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project provides a small 3D sandbox demo built with [Three.js](https://thre
 - Movement with `Z`, `Q`, `S`, `D` and jump with space.
 - Press `Escape` to open the menu where you can adjust render distance and resume with the **Sauvegarder** button.
 - Chunks are loaded and unloaded around the player based on the selected render distance.
+- Game state (player position, seed and render distance) is saved to `localStorage` when you click **Sauvegarder**.
 
 ## Running
 Open `index.html` in a modern web browser that supports WebGL. Click on the page to lock the pointer and start moving.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>Minecraft Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div id="menu" class="hidden">
+  <div class="panel">
+    <label>Distance de rendu: <input id="renderRange" type="range" min="1" max="4" value="2"></label>
+    <button id="saveBtn">Sauvegarder</button>
+  </div>
+</div>
+<script src="lib/three.min.js"></script>
+<script src="lib/perlin.js"></script>
+<script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,263 @@
+// Basic Minecraft-like demo
+let scene, camera, renderer;
+let player, cameraHolder;
+let isThirdPerson = false;
+let velocity = {x:0,y:0,z:0};
+let onGround = false;
+const gravity = 9.81;
+const speed = 5;
+const blockSize = 1;
+const chunkSize = 16;
+let renderDistance = 2;
+let seed = Math.random();
+let savedState = null;
+let yaw=0,pitch=0;
+const chunks = {};
+const blocks = {}; // map "x,y,z" -> mesh
+const keys = {};
+
+function key(e){keys[e.key.toLowerCase()] = e.type==='keydown';}
+
+function init(){
+  const saved = localStorage.getItem('gameState');
+  if(saved){
+    try{
+      savedState = JSON.parse(saved);
+      if(savedState.renderDistance) renderDistance = savedState.renderDistance;
+      if(savedState.seed) seed = savedState.seed;
+    }catch(e){
+      console.warn('Failed to load save', e);
+      savedState = null;
+    }
+  }
+
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x87ceeb); // blue sky
+  camera = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHeight, 0.1, 1000);
+  renderer = new THREE.WebGLRenderer({antialias:true});
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  document.body.appendChild(renderer.domElement);
+
+  cameraHolder = new THREE.Object3D();
+  scene.add(cameraHolder);
+
+  const geometry = new THREE.BoxGeometry(1,2,1);
+  const material = new THREE.MeshBasicMaterial({color:0x00ff00});
+  player = new THREE.Mesh(geometry, material);
+  player.position.y = 3;
+  if(savedState && savedState.player){
+    player.position.set(savedState.player.x, savedState.player.y, savedState.player.z);
+    yaw = savedState.player.yaw || 0;
+    pitch = savedState.player.pitch || 0;
+  }
+  scene.add(player);
+  cameraHolder.add(camera);
+  camera.position.set(0,1,0);
+  updateCamera();
+
+  noise.seed(seed);
+  generateWorld();
+
+  document.addEventListener('keydown', key);
+  document.addEventListener('keyup', key);
+  document.body.addEventListener('click', ()=>{
+    if(!document.pointerLockElement){renderer.domElement.requestPointerLock();}
+  });
+  document.addEventListener('mousemove', onMouseMove);
+  window.addEventListener('resize', onWindowResize);
+  window.addEventListener('beforeunload', saveGame);
+}
+
+function onMouseMove(e){
+  if(!document.pointerLockElement) return;
+  yaw -= e.movementX*0.002;
+  pitch -= e.movementY*0.002;
+  pitch = Math.max(-Math.PI/2, Math.min(Math.PI/2, pitch));
+  updateCamera();
+}
+
+function updateCamera(){
+  cameraHolder.position.copy(player.position);
+  cameraHolder.rotation.set(0,yaw,0);
+  if(isThirdPerson){
+     camera.position.set(0,1,3);
+     camera.lookAt(0,1,0);
+  }else{
+     camera.position.set(0,1,0);
+     camera.rotation.set(pitch,0,0);
+  }
+}
+
+function onWindowResize(){
+  camera.aspect = window.innerWidth/window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function createBlock(){
+  const geom = new THREE.BoxGeometry(blockSize,blockSize,blockSize);
+  const mat = new THREE.MeshLambertMaterial({color:0x888888});
+  const mesh = new THREE.Mesh(geom, mat);
+  const edges = new THREE.EdgesGeometry(geom);
+  const line = new THREE.LineSegments(edges, new THREE.LineBasicMaterial({color:0x444444}));
+  mesh.add(line);
+  return mesh;
+}
+
+function generateChunk(cx,cz){
+  if(chunks[`${cx},${cz}`]) return; // already generated
+  const group = new THREE.Group();
+  for(let x=0;x<chunkSize;x++){
+    for(let z=0;z<chunkSize;z++){
+      const wx=cx*chunkSize+x;
+      const wz=cz*chunkSize+z;
+      const n = noise.perlin2(wx/10,wz/10);
+      const h = Math.floor(n*3)+1; // at least 1 block high
+      for(let y=0;y<h;y++){
+        const block=createBlock();
+        const key=`${wx},${y},${wz}`;
+        block.position.set(wx*blockSize,y*blockSize,wz*blockSize);
+        block.userData.key=key;
+        group.add(block);
+        blocks[key]=block;
+      }
+    }
+  }
+  scene.add(group);
+  chunks[`${cx},${cz}`]=group;
+}
+
+function removeChunk(cx,cz){
+  const key=`${cx},${cz}`;
+  const group=chunks[key];
+  if(!group) return;
+  group.children.forEach(b=>{delete blocks[b.userData.key];});
+  scene.remove(group);
+  delete chunks[key];
+}
+
+function generateWorld(){
+  updateChunks();
+  const light = new THREE.DirectionalLight(0xffffff,1);
+  light.position.set(10,20,10);
+  scene.add(light);
+  const amb = new THREE.AmbientLight(0xcccccc);
+  scene.add(amb);
+}
+
+function updateChunks(){
+  const pcx=Math.floor(player.position.x/(blockSize*chunkSize));
+  const pcz=Math.floor(player.position.z/(blockSize*chunkSize));
+  for(let cx=pcx-renderDistance;cx<=pcx+renderDistance;cx++){
+    for(let cz=pcz-renderDistance;cz<=pcz+renderDistance;cz++){
+      generateChunk(cx,cz);
+    }
+  }
+  for(let key in chunks){
+    const [cx,cz]=key.split(',').map(Number);
+    if(Math.abs(cx-pcx)>renderDistance||Math.abs(cz-pcz)>renderDistance){
+      removeChunk(cx,cz);
+    }
+  }
+}
+
+function updatePlayer(dt){
+  if(keys['z']){velocity.x -= Math.sin(yaw)*speed*dt; velocity.z -= Math.cos(yaw)*speed*dt;}
+  if(keys['s']){velocity.x += Math.sin(yaw)*speed*dt; velocity.z += Math.cos(yaw)*speed*dt;}
+  if(keys['q']){velocity.x -= Math.cos(yaw)*speed*dt; velocity.z += Math.sin(yaw)*speed*dt;}
+  if(keys['d']){velocity.x += Math.cos(yaw)*speed*dt; velocity.z -= Math.sin(yaw)*speed*dt;}
+  velocity.y -= gravity*dt;
+  onGround=false;
+
+  // propose next position
+  let next = player.position.clone();
+  next.x += velocity.x;
+  next.y += velocity.y;
+  next.z += velocity.z;
+
+  // simple collision detection with blocks
+  const bbox = new THREE.Box3().setFromObject(player);
+  bbox.translate(new THREE.Vector3(velocity.x, velocity.y, velocity.z));
+  const pos = new THREE.Vector3();
+  for(let key in blocks){
+    const b = blocks[key];
+    const bb = new THREE.Box3().setFromObject(b);
+    if(bbox.intersectsBox(bb)){
+      // stop vertical movement if hitting from above or below
+      if(player.position.y >= bb.max.y-0.01 && velocity.y<=0){
+         next.y = bb.max.y;
+         velocity.y=0;
+         onGround=true;
+      }else if(player.position.y <= bb.min.y+1 && velocity.y>0){
+         next.y = bb.min.y-2;
+         velocity.y=0;
+      }else{
+         // horizontal collision
+         velocity.x=0;velocity.z=0;
+         next.x=player.position.x;
+         next.z=player.position.z;
+      }
+    }
+  }
+  player.position.copy(next);
+  velocity.x*=0.9;velocity.z*=0.9; // damping
+
+  // if on ground stop vertical velocity
+  if(player.position.y<0){player.position.y=0;velocity.y=0;onGround=true;}
+
+  if(keys[' '] && onGround){
+    velocity.y=5;
+  }
+}
+
+function animate(){
+  requestAnimationFrame(animate);
+  const dt = 0.016; // simplified fixed step
+  updatePlayer(dt);
+  updateChunks();
+  updateCamera();
+  renderer.render(scene,camera);
+}
+
+function toggleView(){
+  isThirdPerson=!isThirdPerson;
+  updateCamera();
+}
+
+document.addEventListener('keydown',e=>{if(e.key.toLowerCase()==='a')toggleView();});
+document.addEventListener('keydown',e=>{if(e.key==='Escape')showMenu(true);});
+
+document.getElementById('saveBtn').addEventListener('click',()=>{
+  renderDistance=parseInt(document.getElementById('renderRange').value,10);
+  saveGame();
+  updateChunks();
+  showMenu(false);
+});
+
+function saveGame(){
+  const data={
+    seed,
+    renderDistance,
+    player:{
+      x:player.position.x,
+      y:player.position.y,
+      z:player.position.z,
+      yaw,
+      pitch
+    }
+  };
+  localStorage.setItem('gameState',JSON.stringify(data));
+}
+function showMenu(show){
+  const menu=document.getElementById('menu');
+  menu.classList.toggle('hidden',!show);
+  if(show){
+     document.getElementById('renderRange').value=renderDistance;
+     document.exitPointerLock();
+  }else{
+     renderer.domElement.requestPointerLock();
+  }
+}
+
+init();
+animate();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,5 @@
+html,body{margin:0;overflow:hidden;height:100%;}
+#menu{position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;}
+#menu.hidden{display:none;}
+#menu .panel{background:rgba(200,200,200,0.5);padding:20px;border-radius:10px;display:flex;flex-direction:column;gap:10px;align-items:center;}
+button{padding:5px 10px;font-size:16px;background:#444;color:#fff;border:none;border-radius:5px;}


### PR DESCRIPTION
## Summary
- restore deleted web demo files
- store render distance and player info in localStorage
- load saved data on start
- document new save feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685abac945608326a259953733fbe018